### PR TITLE
feat: switch to lodash 'dot' packages

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "graphlib",
-  "version": "2.1.9-patch",
+  "version": "2.1.9-patch.2",
   "main": [
     "dist/graphlib.core.js"
   ],
@@ -20,6 +20,21 @@
     "test/**"
   ],
   "dependencies": {
-    "@snyk/lodash": "4.17.15-patch"
+    "lodash.clone": "^4.5.0",
+    "lodash.constant": "^3.0.0",
+    "lodash.filter": "^4.6.0",
+    "lodash.foreach": "^4.5.0",
+    "lodash.has": "^4.5.2",
+    "lodash.isarray": "^4.0.0",
+    "lodash.isempty": "^4.4.0",
+    "lodash.isfunction": "^3.0.9",
+    "lodash.isundefined": "^3.0.1",
+    "lodash.keys": "^4.2.0",
+    "lodash.map": "^4.6.0",
+    "lodash.reduce": "^4.6.0",
+    "lodash.size": "^4.2.0",
+    "lodash.transform": "^4.6.0",
+    "lodash.union": "^4.6.0",
+    "lodash.values": "^4.3.0"
   }
 }

--- a/lib/lodash.js
+++ b/lib/lodash.js
@@ -5,24 +5,23 @@ var lodash;
 
 if (typeof require === "function") {
   try {
-    var _ = require("@snyk/lodash");
     lodash = {
-      clone: _.clone,
-      constant: _.constant,
-      each: _.each,
-      filter: _.filter,
-      has:  _.has,
-      isArray: _.isArray,
-      isEmpty: _.isEmpty,
-      isFunction: _.isFunction,
-      isUndefined: _.isUndefined,
-      keys: _.keys,
-      map: _.map,
-      reduce: _.reduce,
-      size: _.size,
-      transform: _.transform,
-      union: _.union,
-      values: _.values
+      clone: require("lodash.clone"),
+      constant: require("lodash.constant"),
+      each: require("lodash.foreach"),
+      filter: require("lodash.filter"),
+      has:  require("lodash.has"),
+      isArray: require("lodash.isarray"),
+      isEmpty: require("lodash.isempty"),
+      isFunction: require("lodash.isfunction"),
+      isUndefined: require("lodash.isundefined"),
+      keys: require("lodash.keys"),
+      map: require("lodash.map"),
+      reduce: require("lodash.reduce"),
+      size: require("lodash.size"),
+      transform: require("lodash.transform"),
+      union: require("lodash.union"),
+      values: require("lodash.values")
     };
   } catch (e) {
     // continue regardless of error

--- a/lib/version.js
+++ b/lib/version.js
@@ -1,1 +1,1 @@
-module.exports = '2.1.9-patch';
+module.exports = '2.1.9-patch.2';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@snyk/graphlib",
-  "version": "2.1.9-patch",
+  "version": "2.1.9-patch.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -33,7 +33,8 @@
     "@snyk/lodash": {
       "version": "4.17.15-patch",
       "resolved": "https://registry.npmjs.org/@snyk/lodash/-/lodash-4.17.15-patch.tgz",
-      "integrity": "sha512-e4+t34bGyjjRnwXwI14hqye9J/nRbG9iwaqTgXWHskm5qC+iK0UrjgYdWXiHJCf3Plbpr+1rpW+4LPzZnCGMhQ=="
+      "integrity": "sha512-e4+t34bGyjjRnwXwI14hqye9J/nRbG9iwaqTgXWHskm5qC+iK0UrjgYdWXiHJCf3Plbpr+1rpW+4LPzZnCGMhQ==",
+      "dev": true
     },
     "@types/color-name": {
       "version": "1.1.1",
@@ -2767,11 +2768,91 @@
       "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
       "dev": true
     },
+    "lodash.clone": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clone/-/lodash.clone-4.5.0.tgz",
+      "integrity": "sha1-GVhwRQ9aExkkeN9Lw9I9LeoZB7Y="
+    },
+    "lodash.constant": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.constant/-/lodash.constant-3.0.0.tgz",
+      "integrity": "sha1-v+Bczn5RWzEokl1jYhOEIL1iSRA="
+    },
+    "lodash.filter": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.filter/-/lodash.filter-4.6.0.tgz",
+      "integrity": "sha1-ZosdSYFgOuHMWm+nYBQ+SAtMSs4="
+    },
+    "lodash.foreach": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-4.5.0.tgz",
+      "integrity": "sha1-Gmo16s5AEoDH8G3d7DUWWrJ+PlM="
+    },
+    "lodash.has": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/lodash.has/-/lodash.has-4.5.2.tgz",
+      "integrity": "sha1-0Z9NwQlQWMzL4rDN9O4P5Ko3yGI="
+    },
+    "lodash.isarray": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-4.0.0.tgz",
+      "integrity": "sha1-KspJayjEym1yZxUxNZDALm6jRAM="
+    },
+    "lodash.isempty": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.isempty/-/lodash.isempty-4.4.0.tgz",
+      "integrity": "sha1-b4bL7di+TsmHvpqvM8loTbGzHn4="
+    },
+    "lodash.isfunction": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-3.0.9.tgz",
+      "integrity": "sha512-AirXNj15uRIMMPihnkInB4i3NHeb4iBtNg9WRWuK2o31S+ePwwNmDPaTL3o7dTJ+VXNZim7rFs4rxN4YU1oUJw=="
+    },
+    "lodash.isundefined": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isundefined/-/lodash.isundefined-3.0.1.tgz",
+      "integrity": "sha1-I+89lTVWUgOmbO/VuDD4SJEa+0g="
+    },
+    "lodash.keys": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-4.2.0.tgz",
+      "integrity": "sha1-oIYCrBLk+4P5H8H7ejYKTZujUgU="
+    },
+    "lodash.map": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.map/-/lodash.map-4.6.0.tgz",
+      "integrity": "sha1-dx7Hg540c9nEzeKLGTlMNWL09tM="
+    },
     "lodash.memoize": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-3.0.4.tgz",
       "integrity": "sha1-LcvSwofLwKVcxCMovQxzYVDVPj8=",
       "dev": true
+    },
+    "lodash.reduce": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.reduce/-/lodash.reduce-4.6.0.tgz",
+      "integrity": "sha1-8atrg5KZrUj3hKu/R2WW8DuRTTs="
+    },
+    "lodash.size": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.size/-/lodash.size-4.2.0.tgz",
+      "integrity": "sha1-cf517T6r2yvLc6GwtPUcOS7ie4Y="
+    },
+    "lodash.transform": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.transform/-/lodash.transform-4.6.0.tgz",
+      "integrity": "sha1-EjBkIvYzJK7YSD0/ODMrX2cFR6A="
+    },
+    "lodash.union": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
+      "integrity": "sha1-SLtQiECfFvGCFmZkHETdGqrjzYg="
+    },
+    "lodash.values": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.values/-/lodash.values-4.3.0.tgz",
+      "integrity": "sha1-o6bCsOvsxcLLocF+bmIP6BtT00c="
     },
     "log-symbols": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snyk/graphlib",
-  "version": "2.1.9-patch",
+  "version": "2.1.9-patch.2",
   "description": "A directed and undirected multi-graph library",
   "author": "Chris Pettitt <cpettitt@gmail.com>",
   "license": "MIT",
@@ -15,9 +15,25 @@
     "algorithms"
   ],
   "dependencies": {
-    "@snyk/lodash": "4.17.15-patch"
+    "lodash.clone": "^4.5.0",
+    "lodash.constant": "^3.0.0",
+    "lodash.filter": "^4.6.0",
+    "lodash.foreach": "^4.5.0",
+    "lodash.has": "^4.5.2",
+    "lodash.isarray": "^4.0.0",
+    "lodash.isempty": "^4.4.0",
+    "lodash.isfunction": "^3.0.9",
+    "lodash.isundefined": "^3.0.1",
+    "lodash.keys": "^4.2.0",
+    "lodash.map": "^4.6.0",
+    "lodash.reduce": "^4.6.0",
+    "lodash.size": "^4.2.0",
+    "lodash.transform": "^4.6.0",
+    "lodash.union": "^4.6.0",
+    "lodash.values": "^4.3.0"
   },
   "devDependencies": {
+    "@snyk/lodash": "^4.17.15-patch",
     "benchmark": "^2.1.4",
     "browserify": "^16.5.0",
     "chai": "^4.1.2",


### PR DESCRIPTION
This reduces the amount of lodash, and the associated
vulnerabilities, that the megapackage pulls in at runtime.

"backport" of https://github.com/dagrejs/graphlib/pull/118