### PR TITLE
updating repository url

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,6 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/dagrejs/graphlib.git"
+    "url": "https://github.com/snyk/graphlib.git"
   }
 }


### PR DESCRIPTION
This should fix the link on `https://www.npmjs.com/package/@snyk/graphlib`