### PR TITLE
feat: eliminate a few more tiny lodash libraries

### DIFF
--- a/lib/alg/dijkstra.ts
+++ b/lib/alg/dijkstra.ts
@@ -1,8 +1,7 @@
-import _constant from 'lodash.constant';
 import type { Edge, Graph } from '..';
 import PriorityQueue from '../data/priority-queue';
 
-const DEFAULT_WEIGHT_FUNC = _constant(1);
+const DEFAULT_WEIGHT_FUNC = () => 1;
 
 export interface Path {
   distance: number;

--- a/lib/alg/floyd-warshall.ts
+++ b/lib/alg/floyd-warshall.ts
@@ -1,8 +1,7 @@
-import _constant from 'lodash.constant';
 import { Edge, Graph } from '..';
 import { Path } from './dijkstra';
 
-const DEFAULT_WEIGHT_FUNC = _constant(1);
+const DEFAULT_WEIGHT_FUNC = () => 1;
 
 /**
  * This function is an implementation of the Floyd-Warshall algorithm, which finds the

--- a/lib/alg/topsort.ts
+++ b/lib/alg/topsort.ts
@@ -1,5 +1,4 @@
 import _has from 'lodash.has';
-import _size from 'lodash.size';
 
 import type { Graph } from '..';
 
@@ -32,7 +31,7 @@ export function topsort(g: Graph): string[] {
 
   g.sinks()?.forEach(visit);
 
-  if (_size(visited) !== g.nodeCount()) {
+  if (Object.keys(visited).length !== g.nodeCount()) {
     throw new CycleException();
   }
 

--- a/lib/dash.ts
+++ b/lib/dash.ts
@@ -1,0 +1,7 @@
+export function isFunction(func: unknown): func is (...args: any[]) => any {
+  return typeof func === 'function';
+}
+
+export function constant<T>(val: T): () => T {
+  return () => val;
+}

--- a/lib/graph.ts
+++ b/lib/graph.ts
@@ -1,10 +1,10 @@
 /* eslint-disable prefer-rest-params */
-import constant from 'lodash.constant';
 import _filter from 'lodash.filter';
 import isEmpty from 'lodash.isempty';
-import isFunction from 'lodash.isfunction';
 import reduce from 'lodash.reduce';
 import union from 'lodash.union';
+
+import { constant, isFunction } from './dash';
 
 const DEFAULT_EDGE_NAME = '\x00';
 const GRAPH_NODE = '\x00';
@@ -63,10 +63,10 @@ export class Graph {
     this._label = undefined;
 
     // Defaults to be set when creating a new node
-    this._defaultNodeLabelFn = constant(undefined);
+    this._defaultNodeLabelFn = () => undefined;
 
     // Defaults to be set when creating a new edge
-    this._defaultEdgeLabelFn = constant(undefined);
+    this._defaultEdgeLabelFn = () => undefined;
 
     // v -> label
     this._nodes = {};

--- a/package.json
+++ b/package.json
@@ -21,14 +21,11 @@
   },
   "dependencies": {
     "lodash.clone": "^4.5.0",
-    "lodash.constant": "^3.0.0",
     "lodash.filter": "^4.6.0",
     "lodash.has": "^4.5.2",
     "lodash.isempty": "^4.4.0",
-    "lodash.isfunction": "^3.0.9",
     "lodash.map": "^4.6.0",
     "lodash.reduce": "^4.6.0",
-    "lodash.size": "^4.2.0",
     "lodash.transform": "^4.6.0",
     "lodash.union": "^4.6.0"
   },

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "prepare": "tsc",
     "test": "jest",
     "lint": "eslint 'lib/**/*.?s' 'test/**/*test.?s'",
-    "format": "prettier --write 'lib/**/*.?s' 'test/**/*.?s' '*.json' 'test/*.json'"
+    "format": "prettier --write 'lib/**/*.?s' 'test/**/*.?s' '*.json' 'test/*.json' 'scripts/**/*.?s'"
   },
   "dependencies": {
     "lodash.clone": "^4.5.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "devDependencies": {
     "@babel/preset-env": "^7.13.15",
     "@babel/preset-typescript": "^7.13.0",
-    "@types/jest": "^26.0.23",
+    "@types/jest": "^27.0.1",
     "@typescript-eslint/eslint-plugin": "^4.22.0",
     "@typescript-eslint/parser": "^4.22.0",
     "benchmark": "^2.1.4",
@@ -42,9 +42,9 @@
     "jest": "^27.0.0-next.8",
     "lodash": "^4.17.21",
     "prettier": "^2.2.1",
-    "seedrandom": "^2.4.3",
-    "sprintf": "^0.1.5",
-    "ts-node": "^9.1.1",
+    "seedrandom": "^3.0.5",
+    "sprintf-js": "^1.1.2",
+    "ts-node": "^10.2.0",
     "typescript": "~4.3.5"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "seedrandom": "^2.4.3",
     "sprintf": "^0.1.5",
     "ts-node": "^9.1.1",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.5"
   },
   "repository": {
     "type": "git",

--- a/scripts/bench.js
+++ b/scripts/bench.js
@@ -1,17 +1,17 @@
 #!/usr/bin/env node
 
-const Benchmark = require("benchmark"),
-  seedrandom = require("seedrandom"),
-  sprintf = require("sprintf-js").sprintf;
+const Benchmark = require('benchmark'),
+  seedrandom = require('seedrandom'),
+  sprintf = require('sprintf-js').sprintf;
 
 const seed = process.env.SEED;
 seedrandom(seed, { global: true });
 if (seed) {
-  console.log("SEED: %s (%d)", seed, Math.random());
+  console.log('SEED: %s (%d)', seed, Math.random());
 }
 
-const Graph = require("..").Graph,
-  alg = require("..").alg;
+const Graph = require('..').Graph,
+  alg = require('..').alg;
 
 const NODE_SIZES = [100],
   EDGE_DENSITY = 0.2,
@@ -19,26 +19,28 @@ const NODE_SIZES = [100],
 
 function runBenchmark(name, fn) {
   const options = {};
-  options.onComplete = function(bench) {
+  options.onComplete = function (bench) {
     const target = bench.target,
       hz = target.hz,
       stats = target.stats,
       rme = stats.rme,
       samples = stats.sample.length,
-      msg = sprintf("    %25s: %13s ops/sec \xb1 %s%% (%3d run(s) sampled)",
+      msg = sprintf(
+        '    %25s: %13s ops/sec \xb1 %s%% (%3d run(s) sampled)',
         target.name,
         Benchmark.formatNumber(hz.toFixed(2)),
         rme.toFixed(2),
-        samples);
+        samples,
+      );
     console.log(msg);
   };
-  options.onError = function(bench) {
-    console.error("    " + bench.target.error);
+  options.onError = function (bench) {
+    console.error('    ' + bench.target.error);
   };
-  options.setup = function() {
+  options.setup = function () {
     this.count = Math.random() * 1000;
-    this.nextInt = function(range) {
-      return Math.floor(this.count++ % range );
+    this.nextInt = function (range) {
+      return Math.floor(this.count++ % range);
     };
   };
   new Benchmark(name, fn, options).run();
@@ -48,7 +50,7 @@ function keys(count) {
   const ks = [];
   let k;
   for (let i = 0; i < count; ++i) {
-    k = "";
+    k = '';
     for (let j = 0; j < KEY_SIZE; ++j) {
       k += String.fromCharCode(97 + Math.floor(Math.random() * 26));
     }
@@ -62,7 +64,9 @@ function buildGraph(numNodes, edgeDensity) {
     numEdges = numNodes * numNodes * edgeDensity,
     ks = keys(numNodes);
 
-  ks.forEach(function(k) { g.setNode(k); });
+  ks.forEach(function (k) {
+    g.setNode(k);
+  });
 
   for (let i = 0; i < numEdges; ++i) {
     let v, w;
@@ -75,96 +79,100 @@ function buildGraph(numNodes, edgeDensity) {
   return g;
 }
 
-NODE_SIZES.forEach(function(size) {
+NODE_SIZES.forEach(function (size) {
   const g = buildGraph(size, EDGE_DENSITY),
     nodes = g.nodes(),
     edges = g.edges(),
-    nameSuffix = "(" + size + "," + EDGE_DENSITY + ")";
+    nameSuffix = '(' + size + ',' + EDGE_DENSITY + ')';
 
-  runBenchmark("nodes" + nameSuffix, function() {
+  runBenchmark('nodes' + nameSuffix, function () {
     g.nodes();
   });
 
-  runBenchmark("sources" + nameSuffix, function() {
+  runBenchmark('sources' + nameSuffix, function () {
     g.sources();
   });
 
-  runBenchmark("sinks" + nameSuffix, function() {
+  runBenchmark('sinks' + nameSuffix, function () {
     g.sinks();
   });
 
-  runBenchmark("filterNodes all" + nameSuffix, function() {
-    g.filterNodes(function() { return true; });
+  runBenchmark('filterNodes all' + nameSuffix, function () {
+    g.filterNodes(function () {
+      return true;
+    });
   });
 
-  runBenchmark("filterNodes none" + nameSuffix, function() {
-    g.filterNodes(function() { return false; });
+  runBenchmark('filterNodes none' + nameSuffix, function () {
+    g.filterNodes(function () {
+      return false;
+    });
   });
 
-  runBenchmark("setNode" + nameSuffix, function() {
-    g.setNode("key", "label");
+  runBenchmark('setNode' + nameSuffix, function () {
+    g.setNode('key', 'label');
   });
 
-  runBenchmark("node" + nameSuffix, function() {
+  runBenchmark('node' + nameSuffix, function () {
     g.node(nodes[this.nextInt(nodes.length)]);
   });
 
-  runBenchmark("set + removeNode" + nameSuffix, function() {
-    g.setNode("key");
-    g.removeNode("key");
+  runBenchmark('set + removeNode' + nameSuffix, function () {
+    g.setNode('key');
+    g.removeNode('key');
   });
 
-  runBenchmark("predecessors" + nameSuffix, function() {
+  runBenchmark('predecessors' + nameSuffix, function () {
     g.predecessors(nodes[this.nextInt(nodes.length)]);
   });
 
-  runBenchmark("successors" + nameSuffix, function() {
+  runBenchmark('successors' + nameSuffix, function () {
     g.successors(nodes[this.nextInt(nodes.length)]);
   });
 
-  runBenchmark("neighbors" + nameSuffix, function() {
+  runBenchmark('neighbors' + nameSuffix, function () {
     g.neighbors(nodes[this.nextInt(nodes.length)]);
   });
 
-  runBenchmark("edges" + nameSuffix, function() {
+  runBenchmark('edges' + nameSuffix, function () {
     g.edges();
   });
 
-  runBenchmark("setPath" + nameSuffix, function() {
-    g.setPath(["a", "b", "c", "d", "e"]);
+  runBenchmark('setPath' + nameSuffix, function () {
+    g.setPath(['a', 'b', 'c', 'd', 'e']);
   });
 
-  runBenchmark("setEdge" + nameSuffix, function() {
-    g.setEdge("from", "to", "label");
+  runBenchmark('setEdge' + nameSuffix, function () {
+    g.setEdge('from', 'to', 'label');
   });
 
-  runBenchmark("edge" + nameSuffix, function() {
+  runBenchmark('edge' + nameSuffix, function () {
     const edge = edges[this.nextInt(edges.length)];
     g.edge(edge);
   });
 
-  runBenchmark("set + removeEdge" + nameSuffix, function() {
-    g.setEdge("from", "to");
-    g.removeEdge("from", "to");
+  runBenchmark('set + removeEdge' + nameSuffix, function () {
+    g.setEdge('from', 'to');
+    g.removeEdge('from', 'to');
   });
 
-  runBenchmark("inEdges" + nameSuffix, function() {
+  runBenchmark('inEdges' + nameSuffix, function () {
     g.inEdges(nodes[this.nextInt(nodes.length)]);
   });
 
-  runBenchmark("outEdges" + nameSuffix, function() {
+  runBenchmark('outEdges' + nameSuffix, function () {
     g.outEdges(nodes[this.nextInt(nodes.length)]);
   });
 
-  runBenchmark("nodeEdges" + nameSuffix, function() {
+  runBenchmark('nodeEdges' + nameSuffix, function () {
     g.nodeEdges(nodes[this.nextInt(nodes.length)]);
   });
 
-  runBenchmark("components" + nameSuffix, function() {
+  runBenchmark('components' + nameSuffix, function () {
     alg.components(g);
   });
 
-  runBenchmark("dijkstraAll" + nameSuffix, function() {
+  runBenchmark('dijkstraAll' + nameSuffix, function () {
     alg.dijkstraAll(g);
   });
 });

--- a/scripts/bench.js
+++ b/scripts/bench.js
@@ -2,7 +2,7 @@
 
 const Benchmark = require("benchmark"),
   seedrandom = require("seedrandom"),
-  sprintf = require("sprintf").sprintf;
+  sprintf = require("sprintf-js").sprintf;
 
 const seed = process.env.SEED;
 seedrandom(seed, { global: true });


### PR DESCRIPTION
Our bundle size is still massive, and our only dependencies are these huge gobs of lodash. Most of the pain is probably in `_has` (which is wrong anyway), but start by trimming out some of the easier ones.

And perform some general maintenance while we're here.