### PR TITLE
cannot install graphlib

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+just a dummy patch
+
 # @snyk/graphlib
 
 Graphlib is a JavaScript library that provides data structures for undirected

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-just a dummy patch
-
 # @snyk/graphlib
 
 Graphlib is a JavaScript library that provides data structures for undirected

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "algorithms"
   ],
   "scripts": {
-    "prepare": "tsc",
+    "prepare": "tsc --build",
     "test": "jest",
     "lint": "eslint 'lib/**/*.?s' 'test/**/*test.?s'",
     "format": "prettier --write 'lib/**/*.?s' 'test/**/*.?s' '*.json' 'test/*.json' 'scripts/**/*.?s'"


### PR DESCRIPTION
i cannot install graphlib

```sh
cd $(mktemp -d)
npm init -y

# install from npm
pnpm i @snyk/graphlib # ok
ls node_modules/@snyk/graphlib/dist # No such file or directory = build failed

# install from git
pnpm i https://github.com/snyk/graphlib.git # ok
ls node_modules/@snyk/graphlib/dist # No such file or directory = build failed

# manually run prepare
cd node_modules/@snyk/graphlib
pnpm install #  ELIFECYCLE  Command failed with exit code 1.
```


[graphlib/package.json](https://github.com/snyk/graphlib/blob/master/package.json#L16)

```json
  "scripts": {
    "prepare": "tsc",
```

should be

```json
  "scripts": {
    "prepare": "tsc --build",
```

patched

```sh
pnpm i https://github.com/milahu/graphlib.git#007b74375cf6a8c2515aea50b35db8a5fbfdfcaf
ls node_modules/@snyk/graphlib/dist # ok
```

this is blocking https://github.com/snyk/nodejs-lockfile-parser/issues/132

ps: maybe enable github issues
